### PR TITLE
support everything in `hlint`

### DIFF
--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -176,6 +176,7 @@ instance NameGraph (Pat Name) where
     VarPat p -> withoutUsedNames [p]
     TuplePat pats _ _ -> nameGraph pats
     WildPat _ -> []
+    LazyPat p -> nameGraph p
     pat -> errorNyiOutputable pat
 
 instance NameGraph (TyClGroup Name) where

--- a/src/Ast.hs
+++ b/src/Ast.hs
@@ -147,7 +147,7 @@ instance NameGraph Module where
 
 instance NameGraph (HsGroup Name) where
   nameGraph = \ case
-    HsGroup valBinds [] tyclds _instances _standaloneInstances [] [] foreign_decls [] [] [] [] [] ->
+    HsGroup valBinds [] tyclds _instances _standaloneInstances [] [] foreign_decls [] _annotations [] [] [] ->
       nameGraph valBinds ++
       nameGraph tyclds ++
       nameGraph foreign_decls

--- a/src/Ast/UsedNames.hs
+++ b/src/Ast/UsedNames.hs
@@ -53,6 +53,7 @@ instance UsedNames (Pat Name) where
     BangPat pat -> usedNames pat
     NPat{} -> []
     LitPat{} -> []
+    LazyPat pat -> usedNames pat
     x -> errorNyiOutputable x
 
 instance UsedNames (HsConDetails (LPat Name) (HsRecFields Name (LPat Name))) where

--- a/test/AstSpec.hs
+++ b/test/AstSpec.hs
@@ -195,6 +195,13 @@ spec = do
           parseStringGraph ["Foo.hs"] `shouldReturn`
             Graph [("Foo.a", []), ("Foo.b", [])] []
 
+      it "can parse lazy patterns" $ do
+        withFooHeader [i|
+          ~(a, b) = let x = x in x
+        |] $ do
+          parseStringGraph ["Foo.hs"] `shouldReturn`
+            Graph [("Foo.a", []), ("Foo.b", [])] []
+
     context "local variables" $ do
       it "recognizes recursive definitions" $ do
         withFooHeader [i|

--- a/test/AstSpec.hs
+++ b/test/AstSpec.hs
@@ -180,6 +180,13 @@ spec = do
       |] $ do
         (usageGraph <$> parseStringGraph ["Foo.hs"]) `shouldReturn` [("Foo.Foo", [])]
 
+    it "ignores annotations" $ do
+      withFooHeader [i|
+        {-# ANN foo "annotation" #-}
+        foo = 42
+      |] $ do
+        (usageGraph <$> parseStringGraph ["Foo.hs"]) `shouldReturn` [("Foo.foo",[])]
+
     context "PatBind" $ do
       it "can parse pattern binding" $ do
         withFooHeader [i|


### PR DESCRIPTION
@ndmitchell: `hlint` uses `ANN` pragmas and `dead-code-detection` doesn't know how to handle those. And then it chokes on e.g. this: https://github.com/ndmitchell/hlint/blob/master/src/HLint.hs#L117. I've never used annotations, so I'm a bit unsure how they work and how this should be handled in `dead-code-detection`. It seems like you can just annotate top-level identifiers with arbitrary haskell expressions. If so, should they be ignored by this tool? Or is using an identifier in an annotation good enough for it to be considered non-dead code?
