### PR TITLE
Add --ignore-files option

### DIFF
--- a/src/Run.hs
+++ b/src/Run.hs
@@ -24,7 +24,7 @@ import           Utils
 data Options
   = Options {
     sourceDirs :: [FilePath],
-    ignoreFiles :: [FilePath],
+    ignore :: [FilePath],
     root :: [String],
     version :: Bool,
     includeUnderscoreNames :: Bool
@@ -36,14 +36,14 @@ instance HasArguments Options
 run :: IO ()
 run = do
   let mods = [AddShortOption "sourceDirs" 'i',
-              AddShortOption "ignoreFiles" 'e']
+              AddShortOption "ignore" 'e']
   withCliModified mods $ \ options -> do
     when (version options) $ do
       putStrLn versionOutput
       throwIO ExitSuccess
     when (null $ root options) $
       die "missing option: --root=STRING"
-    files <- filter (`notElem` ignoreFiles options) <$>
+    files <- filter (`notElem` ignore options) <$>
       findHaskellFiles (sourceDirs options)
     deadNames <- deadNamesFromFiles
       files

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -24,6 +24,7 @@ import           Utils
 data Options
   = Options {
     sourceDirs :: [FilePath],
+    ignoreFiles :: [FilePath],
     root :: [String],
     version :: Bool,
     includeUnderscoreNames :: Bool
@@ -34,14 +35,16 @@ instance HasArguments Options
 
 run :: IO ()
 run = do
-  let mods = [AddShortOption "sourceDirs" 'i']
+  let mods = [AddShortOption "sourceDirs" 'i',
+              AddShortOption "ignoreFiles" 'e']
   withCliModified mods $ \ options -> do
     when (version options) $ do
       putStrLn versionOutput
       throwIO ExitSuccess
     when (null $ root options) $
       die "missing option: --root=STRING"
-    files <- findHaskellFiles (sourceDirs options)
+    files <- filter (`notElem` ignoreFiles options) <$>
+      findHaskellFiles (sourceDirs options)
     deadNames <- deadNamesFromFiles
       files
       (map mkModuleName (root options))

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -63,8 +63,7 @@ spec = do
             main = return ()
           |])
           b = ("B", [i|
-            module B where
-            unused = ()
+            This is some arbitrary text that is not Haskell.
             |])
           run' = withArgs (words "-i. -e./B.hs --root Main") run
       withModules [main, b] $ run' `shouldReturn` ()

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -57,6 +57,18 @@ spec = do
         withArgs ["--version"] run
       output `shouldContain` "version: "
 
+    it "ignores files if told to do so" $ do
+      let main = ("Main", [i|
+            module Main where
+            main = return ()
+          |])
+          b = ("B", [i|
+            module B where
+            unused = ()
+            |])
+          run' = withArgs (words "-i. -e./B.hs --root Main") run
+      withModules [main, b] $ run' `shouldReturn` ()
+
   describe "deadNamesFromFiles" $ do
     it "should clearly mark ghc's output as such" $ do
       let a = ("A", [i|


### PR DESCRIPTION
This should close #7.
I chose `-e` for `exclude` as the short option because `--source-dirs`  has `-i` for `include`.
